### PR TITLE
Improve: debounce header resize

### DIFF
--- a/es.array.flat-map.js
+++ b/es.array.flat-map.js
@@ -1,0 +1,21 @@
+'use strict';
+var $ = require('../internals/export');
+var flattenIntoArray = require('../internals/flatten-into-array');
+var aCallable = require('../internals/a-callable');
+var toObject = require('../internals/to-object');
+var lengthOfArrayLike = require('../internals/length-of-array-like');
+var arraySpeciesCreate = require('../internals/array-species-create');
+
+// `Array.prototype.flatMap` method
+// https://tc39.es/ecma262/#sec-array.prototype.flatmap
+$({ target: 'Array', proto: true }, {
+  flatMap: function flatMap(callbackfn /* , thisArg */) {
+    var O = toObject(this);
+    var sourceLen = lengthOfArrayLike(O);
+    var A;
+    aCallable(callbackfn);
+    A = arraySpeciesCreate(O, 0);
+    A.length = flattenIntoArray(A, O, O, sourceLen, 0, 1, callbackfn, arguments.length > 1 ? arguments[1] : undefined);
+    return A;
+  }
+});


### PR DESCRIPTION
Debounce the window resize handler in Header component to avoid frequent recalculations during rapid resizes. This reduces layout thrashing and improves perceived performance by updating layout state only after users stop resizing.