### PR TITLE
Add debounce to search input

### DIFF
--- a/ImageRole.js
+++ b/ImageRole.js
@@ -1,0 +1,22 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var ImageRole = {
+  relatedConcepts: [{
+    module: 'ARIA',
+    concept: {
+      name: 'img'
+    }
+  }, {
+    module: 'HTML',
+    concept: {
+      name: 'img'
+    }
+  }],
+  type: 'structure'
+};
+var _default = ImageRole;
+exports["default"] = _default;


### PR DESCRIPTION
Add a 300ms debounce to the global search input to reduce excessive API calls and avoid race conditions during rapid typing. Implement cancellation of in-flight requests and update unit tests to cover the debounced behavior.