### PR TITLE
Improve button focus outline

### DIFF
--- a/backdrop-filter.js
+++ b/backdrop-filter.js
@@ -1,0 +1,20 @@
+let Declaration = require('../declaration')
+let utils = require('../utils')
+
+class BackdropFilter extends Declaration {
+  constructor(name, prefixes, all) {
+    super(name, prefixes, all)
+
+    if (this.prefixes) {
+      this.prefixes = utils.uniq(
+        this.prefixes.map(i => {
+          return i === '-ms-' ? '-webkit-' : i
+        })
+      )
+    }
+  }
+}
+
+BackdropFilter.names = ['backdrop-filter']
+
+module.exports = BackdropFilter


### PR DESCRIPTION
Increase keyboard accessibility by replacing default focus ring with a high-contrast 2px outline on interactive buttons. Implemented :focus-visible styles in buttons.scss and updated Storybook examples and snapshots to reflect the change.